### PR TITLE
Use `Object.keys` and outsource getting of symbols

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,6 @@
-var propIsEnumerable = Object.prototype.propertyIsEnumerable
+var getOwnEnumSymbols = require('get-own-enumerable-property-symbols')
 
 module.exports = ownEnumerableKeys
 function ownEnumerableKeys (obj) {
-  var keys = Object.getOwnPropertyNames(obj)
-
-  if (Object.getOwnPropertySymbols) {
-    keys = keys.concat(Object.getOwnPropertySymbols(obj))
-  }
-
-  return keys.filter(function (key) {
-    return propIsEnumerable.call(obj, key)
-  })
+  return Object.keys(obj).concat(Object.getOwnPropertySymbols ? getOwnEnumSymbols(obj) : [])
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "email": "dave.des@gmail.com",
     "url": "https://github.com/mattdesl"
   },
-  "dependencies": {},
+  "dependencies": {
+    "get-own-enumerable-property-symbols": "^1.0.1"
+  },
   "devDependencies": {
     "babel": "^5.6.23",
     "faucet": "0.0.1",


### PR DESCRIPTION
See here for compatibility:
http://kangax.github.io/compat-table/es5/

So there are two changes here:
1. use Object.keys instead of getOwnPropertyNames.
This saves us the filtering of "normal" keys.
Semver-major!
2. Use (my) getOwnEnumerablePropertySymbols.
I don't mean to force two separate things into one commit.
Since this is already a complete rewrite, I don't mind.
Retain check for existence of `Object.getOwnPropertySymbols`
because it is newer than `Object.key`. Yet, If you won't mind,
I wouldn't mind dropping this check, as well.